### PR TITLE
ci: configure Claude workflow with Playwright MCP and project setup

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,21 +30,36 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Project Setup
+        run: |
+          npm run setup
+          npm run dev:daemon
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
-          # This is an optional setting that allows Claude to read CI results on PRs
-          additional_permissions: |
-            actions: read
+          custom_instructions: |
+            The project is already set up with all dependencies installed.
+            The server is already running at localhost:3000. Logs from it
+            are being written to logs.txt. If needed, you can query the
+            db with the 'sqlite3' cli. If needed, use the mcp__playwright
+            set of tools to launch a browser and interact with the app.
 
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
+          mcp_config: |
+            {
+              "mcpServers": {
+                "playwright": {
+                  "command": "npx",
+                  "args": [
+                    "@playwright/mcp@latest",
+                    "--allowed-origins",
+                    "localhost:3000;cdn.tailwindcss.com;esm.sh"
+                  ]
+                }
+              }
+            }
 
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
-
+          allowed_tools: "Bash(npm:*),Bash(sqlite3:*),mcp__playwright__browser_snapshot,mcp__playwright__browser_click,mcp__playwright__browser_navigate,mcp__playwright__browser_type,mcp__playwright__browser_fill,mcp__playwright__browser_select,mcp__playwright__browser_check,mcp__playwright__browser_screenshot,mcp__playwright__browser_close,mcp__playwright__browser_tab_new,mcp__playwright__browser_tab_list,mcp__playwright__browser_tab_select,mcp__playwright__browser_tab_close,mcp__playwright__browser_back,mcp__playwright__browser_forward,mcp__playwright__browser_reload,mcp__playwright__browser_wait_for,mcp__playwright__browser_hover,mcp__playwright__browser_drag,mcp__playwright__browser_key_press,mcp__playwright__browser_scroll,mcp__playwright__browser_evaluate,mcp__playwright__browser_network_requests,mcp__playwright__browser_console_messages,mcp__playwright__browser_resize,mcp__playwright__browser_handle_dialog,mcp__playwright__browser_file_upload"


### PR DESCRIPTION
## Summary

Improves the Claude Code GitHub Actions workflow with a proper project setup step, Playwright MCP integration, and a complete allowed_tools list.

## Changes

- **Project Setup step**: runs npm run setup and npm run dev:daemon so the app is live at localhost:3000 before Claude starts
- **Custom instructions**: gives Claude context about the running server, logs.txt, sqlite3 CLI, and the mcp__playwright toolset
- **Playwright MCP config**: registers @playwright/mcp@latest with allowed origins localhost:3000, cdn.tailwindcss.com, esm.sh
- **Full allowed_tools**: expands the ... placeholder to include all Playwright browser tools (navigate, click, type, fill, select, hover, drag, scroll, screenshot, evaluate, network, console, tabs, dialogs, file upload, etc.) plus Bash for npm and sqlite3